### PR TITLE
Setup rnx-dep-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,14 +7,16 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "test": "jest",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "check-dependencies": "rnx-dep-check",
+    "fix-dependencies": "rnx-dep-check --write"
   },
   "dependencies": {
     "@rnx-kit/metro-config": "^1.3.1",
     "@rnx-kit/metro-resolver-symlinks": "^0.1.21",
     "jsc-android": "^250230.2.1",
     "react": "18.1.0",
-    "react-native": "0.70.1",
+    "react-native": "^0.70.0",
     "react-native-gradle-plugin": "^0.71.4"
   },
   "devDependencies": {
@@ -24,6 +26,7 @@
     "@react-native-community/cli-platform-android": "^9.1.0",
     "@react-native-community/cli-platform-ios": "^9.1.2",
     "@react-native-community/eslint-config": "^2.0.0",
+    "@rnx-kit/dep-check": "^1.13.0",
     "@testing-library/react-native": "^11.2.0",
     "@tsconfig/react-native": "^2.0.2",
     "@types/jest": "^26.0.23",
@@ -36,12 +39,26 @@
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "jest": "^28.0.0",
-    "metro-config": "^0.72.3",
+    "jest": "^26.6.3",
+    "metro-config": "^0.72.1",
     "metro-react-native-babel-preset": "^0.72.1",
     "prettier": "2.7.1",
     "react-test-renderer": "18.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.3"
+  },
+  "rnx-kit": {
+    "reactNativeVersion": "^0.70",
+    "kitType": "app",
+    "capabilities": [
+      "babel-preset-react-native",
+      "core",
+      "core-android",
+      "core-ios",
+      "jest",
+      "metro-config",
+      "react",
+      "react-test-renderer"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ specifiers:
   '@react-native-community/cli-platform-android': ^9.1.0
   '@react-native-community/cli-platform-ios': ^9.1.2
   '@react-native-community/eslint-config': ^2.0.0
+  '@rnx-kit/dep-check': ^1.13.0
   '@rnx-kit/metro-config': ^1.3.1
   '@rnx-kit/metro-resolver-symlinks': ^0.1.21
   '@testing-library/react-native': ^11.2.0
@@ -48,6 +49,7 @@ devDependencies:
   '@react-native-community/cli-platform-android': 9.1.0
   '@react-native-community/cli-platform-ios': 9.1.2
   '@react-native-community/eslint-config': 2.0.0_3rubbgt5ekhqrcgx4uwls3neim
+  '@rnx-kit/dep-check': 1.13.0
   '@testing-library/react-native': 11.2.0_mhtp35tymlazyakvessueomyk4
   '@tsconfig/react-native': 2.0.2
   '@types/jest': 26.0.24
@@ -1933,6 +1935,12 @@ packages:
     dependencies:
       chalk: 4.1.2
     dev: false
+
+  /@rnx-kit/dep-check/1.13.0:
+    resolution: {integrity: sha512-fisE8pssSCh57tCbhv8LqdF3h9RPj4AZXvQTbWEPw7SiVPhmP525sKXw39RyEU0iSkJwgjLO3ZH2T76dbIxRHQ==}
+    engines: {node: '>=12.13'}
+    hasBin: true
+    dev: true
 
   /@rnx-kit/metro-config/1.3.1_ycz3ezxm435c2bj6uh2z72ck2u:
     resolution: {integrity: sha512-HB4zApKYmaduyxgDVKpmjk5yuwFhSTUB2yrhCWsV98N27UK7v8Z3eI2gESKYkozuNXPUfcJKORdwjqwfiefNPg==}


### PR DESCRIPTION
# Changelog
This PR integrates `rnx-dep-check` library as the main dependency manager to safely update the project's dependencies with its core libraries `react` and `react-native` in the future

Read more [here](https://microsoft.github.io/rnx-kit/docs/guides/getting-started)

## TODO
Will integrate this with Github actions in the future